### PR TITLE
Error code changes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+kernelstub (2.2.1) bionic; urgency=medium
+
+  * Cause kernelstub to exit without an error code if the initrd or kernel
+    images can't be found.
+
+ -- Ian Santopietro <ian@system76.com>  Wed, 23 May 2018 14:14:34 -0600
+
 kernelstub (2.2.0) bionic; urgency=medium
 
   * Added an option to add kernel options

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -156,13 +156,13 @@ class Kernelstub():
             log.exception('Can\'t find the kernel image! \n\n'
                          'Please use the --kernel-path option to specify '
                          'the path to the kernel image')
-            exit(166)
+            exit(0)
 
         if not os.path.exists(opsys.initrd_path):
             log.exception('Can\'t find the initrd image! \n\n'
                          'Please use the --initrd-path option to specify '
                          'the path to the initrd image')
-            exit(167)
+            exit(0)
 
         # Check for kernel parameters. Without them, stop and fail
         if args.k_options:

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class Test(Command):
             run_pyflakes3()
 
 setup(name='kernelstub',
-    version='2.2.0',
+    version='2.2.1',
     description='Automatic kernel efistub manager for UEFI',
     url='https://launchpad.net/kernelstub',
     author='Ian Santopietro',


### PR DESCRIPTION
If the kernel or initrd images can't be found, we need to exit with 0
so that kernel updates don't fail.