### PR TITLE
Fix use of invalid index if os entry is not found

### DIFF
--- a/kernelstub/nvram.py
+++ b/kernelstub/nvram.py
@@ -42,7 +42,8 @@ class NVRAM():
         self.log.debug('Updating NVRAM info')
         self.nvram = self.get_nvram()
         self.find_os_entry(self.nvram, self.os_label)
-        self.order_num = str(self.nvram[self.os_entry_index])[4:8]
+        if self.os_entry_index >= 0:
+            self.order_num = str(self.nvram[self.os_entry_index])[4:8]
 
     def get_nvram(self):
         self.log.debug('Getting NVRAM data')


### PR DESCRIPTION
This applies the same logic found here: https://github.com/isantop/kernelstub/blob/master/kernelstub/installer.py#L193

It will not try to index into nvram if the os_entry_index is invalid, and will leave the order_num unset