### PR TITLE
Kernelstub 3.1.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kernelstub (3.1.0) bionic; urgency=medium
+
+  * Add logging to systemd journald
+
+ -- Ian Santopietro <ian@system76.com>  Tue, 25 Sep 2018 10:53:23 -0600
+
 kernelstub (3.0.0) bionic; urgency=medium
 
   * Breaking API Change in 2.3.0

--- a/debian/control
+++ b/debian/control
@@ -12,6 +12,7 @@ Standards-Version: 3.9.1
 Package: kernelstub
 Architecture: all
 Depends: ${misc:Depends}, ${python3:Depends}, efibootmgr, util-linux
+Recommends: python3-systemd
 Description: Automatic kernel efistub manager for UEFI
 
 Package: pop-boot

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -41,11 +41,12 @@ terms.
 
 import logging, os
 
+systemd_support = False
 try:
     from systemd.journal import JournalHandler
+    systemd_support = True
 
 except ImportError:
-    systemd_support = False
     pass
 
 import logging.handlers as handlers

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -125,7 +125,7 @@ class Kernelstub():
 
         if systemd_support:
             journald_log = JournalHandler()
-            journald_log.setLevel(level[1])
+            journald_log.setLevel(file_level)
             journald_log.setFormatter(stream_fmt)
             log.addHandler(journald_log)
 

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -41,6 +41,13 @@ terms.
 
 import logging, os
 
+try:
+    from systemd.journald import JournaldLogHandler
+
+except ImportError:
+    systemd_support = False
+    pass
+
 import logging.handlers as handlers
 
 from . import drive as Drive
@@ -112,9 +119,15 @@ class Kernelstub():
         file_log.setFormatter(file_fmt)
         file_log.setLevel(file_level)
 
-
         log.addHandler(console_log)
         log.addHandler(file_log)
+
+        if systemd_support:
+            journald_log = JournalHandler()
+            journald_log.setLevel(level[1])
+            journald_log.setFormatter(stream_fmt)
+            log.addHandler(journald_log)
+
         log.setLevel(logging.DEBUG)
 
         log.debug('Got command line options: %s' % args)

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -42,7 +42,7 @@ terms.
 import logging, os
 
 try:
-    from systemd.journald import JournaldLogHandler
+    from systemd.journal import JournalHandler
 
 except ImportError:
     systemd_support = False

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class Test(Command):
             run_pyflakes3()
 
 setup(name='kernelstub',
-    version='3.0.0',
+    version='3.1.0',
     description='Automatic kernel efistub manager for UEFI',
     url='https://launchpad.net/kernelstub',
     author='Ian Santopietro',


### PR DESCRIPTION
Releases Kernelstub 3.1.0

This release adds support for systemd journald logging. If the `python3-systemd` package is installed, or the `systemd` package is installed from pip3, kernelstub will enable logging to the systemd journal in addition to console and file logging. Without this support, it silently falls back to logging to file and console only. 

We want to continue logging to file, since this is an easily grepable format for logging and we already practice responsible log file rotation. This also simplifies the fallback to logging without systemd in the event the support is not installed or not desired, or if the system does not have systemd.