### PR TITLE
Fedora/Non-Symlink Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,15 +31,28 @@ dh-python
 
 Then use these commands to build the package:
 ```
-git clone https://github.com/pop-os/kernelstub
+git clone https://github.com/isantop/kernelstub
 cd kernelstub
 dpkg-buildpackage -b -us -uc
 sudo dpkg -i ../kernelstub*.deb
 ```
-For installation on non-debian systems, or if you prefer to use Python
+
+For installation on RPM-based systems (Fedora, RHEL, etc.), the Python packaging
+can automatically build an RPM package for use on your system:
+```
+git clone https://github.com/isantop/kernelstub
+cd kernelstub
+python3 setup.py bdist_rpm
+```
+After this, you can install the resulting RPM package directly:
+```
+sudo rpm -i dist/kernelstub-*.rpm
+```
+
+For installation on other systems, or if you prefer to use Python
 packaging, use:
 ```
-git clone https://github.com/pop-os/kernelstub
+git clone https://github.com/isantop/kernelstub
 cd kernelstub
 sudo python3 setup.py install --record=installed_files.txt
 ```

--- a/data/initramfs/zz-kernelstub
+++ b/data/initramfs/zz-kernelstub
@@ -3,13 +3,18 @@
 # Grab OS information to figure out how to operate
 source /etc/os-release
 
+# If ID_LIKE is empty, use ID instead. Base Distros don't always use ID_LIKE
+if [[ "$ID_LIKE" == "" ]]; then 
+  ID_LIKE="$ID"
+fi
+
 # Determine how to handle kernel paths:
 if [[ "$ID_LIKE" == *"fedora"* ]]; then
   echo "Operating in Fedora-mode (initramfs, /boot)"
   INITRD="/boot/initramfs-$1.img"
-  KERNEL="/boot/vmlinuz-$1"
-elif [[ "$ID_LIKE" == *"ubuntu"* ]]; then
-  echo "Operating in Ubuntu-mode (initrd.img, /symlinks)"
+  KERNEL="$2"
+elif [[ "$ID_LIKE" == *"debian"* ]]; then
+  echo "Operating in Debian-mode (initrd.img, /symlinks)"
   INITRD="/initrd.img"
   KERNEL="/vmlinuz"
 fi

--- a/data/initramfs/zz-kernelstub
+++ b/data/initramfs/zz-kernelstub
@@ -1,8 +1,21 @@
 #!/bin/bash
 
-KERNEL="/boot/vmlinuz-$1"
-INITRD="$2"
+# Grab OS information to figure out how to operate
+source /etc/os-release
+
+# Determine how to handle kernel paths:
+if [[ "$ID_LIKE" == *"fedora"* ]]; then
+  echo "Operating in Fedora-mode (initramfs, /boot)"
+  INITRD="/boot/initramfs-$1.img"
+  KERNEL="/boot/vmlinuz-$1"
+elif [[ "$ID_LIKE" == *"ubuntu"* ]]; then
+  echo "Operating in Ubuntu-mode (initrd.img, /symlinks)"
+  INITRD="/initrd.img"
+  KERNEL="/vmlinuz"
+fi
 
 kernelstub \
   --verbose \
-  --preserve-live-mode
+  --preserve-live-mode \
+  --kernel-path $KERNEL \
+  --initrd-path $INITRD

--- a/data/kernel/zz-kernelstub
+++ b/data/kernel/zz-kernelstub
@@ -13,8 +13,8 @@ if [[ "$ID_LIKE" == *"fedora"* ]]; then
   echo "Operating in Fedora-mode (initramfs, /boot)"
   INITRD="/boot/initramfs-$1.img"
   KERNEL="$2"
-elif [[ "$ID_LIKE" == *"ubuntu"* ]]; then
-  echo "Operating in Ubuntu-mode (initrd.img, /symlinks)"
+elif [[ "$ID_LIKE" == *"debian"* ]]; then
+  echo "Operating in Debian-mode (initrd.img, /symlinks)"
   INITRD="/initrd.img"
   KERNEL="/vmlinuz"
 fi

--- a/data/kernel/zz-kernelstub
+++ b/data/kernel/zz-kernelstub
@@ -1,8 +1,21 @@
 #!/bin/bash
 
-INITRD="/boot/initrd.img-$1"
-KERNEL="$2"
+# Grab OS information to figure out how to operate
+source /etc/os-release
+
+# Determine how to handle kernel paths:
+if [[ "$ID_LIKE" == *"fedora"* ]]; then
+  echo "Operating in Fedora-mode (initramfs, /boot)"
+  INITRD="/boot/initramfs-$1.img"
+  KERNEL="$2"
+elif [[ "$ID_LIKE" == *"ubuntu"* ]]; then
+  echo "Operating in Ubuntu-mode (initrd.img, /symlinks)"
+  INITRD="/initrd.img"
+  KERNEL="/vmlinuz"
+fi
 
 kernelstub \
   --verbose \
-  --preserve-live-mode
+  --preserve-live-mode \
+  --kernel-path $KERNEL \
+  --initrd-path $INITRD

--- a/data/kernel/zz-kernelstub
+++ b/data/kernel/zz-kernelstub
@@ -3,6 +3,11 @@
 # Grab OS information to figure out how to operate
 source /etc/os-release
 
+# If ID_LIKE is empty, use ID instead. Base Distros don't always use ID_LIKE
+if [[ "$ID_LIKE" == "" ]]; then 
+  ID_LIKE="$ID"
+fi
+
 # Determine how to handle kernel paths:
 if [[ "$ID_LIKE" == *"fedora"* ]]; then
   echo "Operating in Fedora-mode (initramfs, /boot)"

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kernelstub (4.0.1) bionic; urgency=medium
+
+  * Add support for Fedora-like kernel setups
+
+ -- Ian Santopietro <isantop@gmail.com>  Wed, 09 Aug 2023 17:18:19 -0600
+
 kernelstub (3.1.4) bionic; urgency=medium
 
   * Do live mode check immediately after parsing config

--- a/kernelstub/kernel_option.py
+++ b/kernelstub/kernel_option.py
@@ -1,6 +1,18 @@
 #!/usr/bin/python3
 
-from debian.changelog import Version
+try:
+    from debian.changelog import Version
+    def vCompare(version1:str, version2:str):
+        if Version(version1) > Version(version2):
+            return True
+        return False
+        
+except ImportError:
+    from rpm import versionCompare as Version
+    def vCompare(version1:str, version2:str):
+        if versionCompare(version1, version2) == 1:
+            return True
+        return False
 import os
 import os.path
 
@@ -11,6 +23,8 @@ def options(path):
         if name.startswith("vmlinuz-"):
             key = "kernel"
         elif name.startswith("initrd.img-"):
+            key = "initrd"
+        elif name.startswith("initramfs"):
             key = "initrd"
 
         if key is None:
@@ -36,7 +50,7 @@ def get_newest_option(opts):
             continue
 
         # If this option is newer, store this option and continue
-        if latest_version is None or Version(version) > Version(latest_version):
+        if latest_version is None or vCompare (version, latest_version):
             latest_version = version
             latest_option = option
     

--- a/kernelstub/kernel_option.py
+++ b/kernelstub/kernel_option.py
@@ -23,16 +23,16 @@ import os.path
 def options(path):
     items={}
     for name in os.listdir(path):
-        log.info('Checking item %s', name)
+        log.debug('Checking item %s', name)
         key = None
         if name.startswith("vmlinuz-"):
-            log.info('Item %s is kernel-image', name)
+            log.debug('Item %s is kernel-image', name)
             key = "kernel"
         elif name.startswith("initrd.img-"):
-            log.info('Item %s is debian-style initrd', name)
+            log.debug('Item %s is debian-style initrd', name)
             key = "initrd"
         elif name.startswith("initramfs"):
-            log.info('Item %s is fedora-style initrd', name)
+            log.debug('Item %s is fedora-style initrd', name)
             key = "initrd"
 
         if key is None:
@@ -42,39 +42,39 @@ def options(path):
         version = parts[1]
         if version.endswith('.img'):
             version = version[:-4]
-        log.info('Item version is %s', version)
+        log.debug('Item version is %s', version)
 
         if not version in items:
-            log.info('Adding item %s to list', name)
+            log.debug('Adding item %s to list', name)
             items[version] = {}
 
         items[version][key] = os.path.join(path, name)
 
-    log.info('Found items: %s', items)
+    log.debug('Found items: %s', items)
     return items
 
 def get_newest_option(opts):
-    log.info('Getting latest boot item version')
+    log.debug('Getting latest boot item version')
     latest_version = None
     latest_option = None
 
     for version, option in opts.items():
-        log.info('Checking option %s', option)
+        log.debug('Checking option %s', option)
         # If option is not complete, skip
         if 'kernel' not in option or 'initrd' not in option:
-            log.info('%s does not contain all items, skipping...', version)
+            log.debug('%s does not contain all items, skipping...', version)
             continue
 
         # If this option is newer, store this option and continue
         if latest_version is None or vCompare (version, latest_version):
-            log.info('%s is the latest version', version)
+            log.debug('%s is the latest version', version)
             latest_version = version
             latest_option = option
     
     return latest_option, latest_version
 
 def latest_option(path):
-    log.info('Checking for boot items in %s', path)
+    log.debug('Checking for boot items in %s', path)
     opts = options(path)
     latest_option, latest_version = get_newest_option(opts)
     
@@ -84,8 +84,8 @@ def latest_option(path):
     if len(opts) > 0:
         previous_option, latest_version = get_newest_option(opts)
 
-    log.info('Latest option: %s', latest_option)
-    log.info('Previous option: %s', previous_option)
+    log.debug('Latest option: %s', latest_option)
+    log.debug('Previous option: %s', previous_option)
     return latest_option, previous_option
 
 if __name__ == "__main__":

--- a/kernelstub/kernel_option.py
+++ b/kernelstub/kernel_option.py
@@ -1,5 +1,9 @@
 #!/usr/bin/python3
 
+import logging
+
+log = logging.getLogger('kernelstub.kernel_option')
+
 try:
     from debian.changelog import Version
     def vCompare(version1:str, version2:str):
@@ -8,9 +12,9 @@ try:
         return False
         
 except ImportError:
-    from rpm import versionCompare as Version
+    from rpm import labelCompare
     def vCompare(version1:str, version2:str):
-        if versionCompare(version1, version2) == 1:
+        if labelCompare(version1, version2) == 1:
             return True
         return False
 import os
@@ -19,12 +23,16 @@ import os.path
 def options(path):
     items={}
     for name in os.listdir(path):
+        log.info('Checking item %s', name)
         key = None
         if name.startswith("vmlinuz-"):
+            log.info('Item %s is kernel-image', name)
             key = "kernel"
         elif name.startswith("initrd.img-"):
+            log.info('Item %s is debian-style initrd', name)
             key = "initrd"
         elif name.startswith("initramfs"):
+            log.info('Item %s is fedora-style initrd', name)
             key = "initrd"
 
         if key is None:
@@ -32,31 +40,41 @@ def options(path):
 
         parts = name.split("-", 1)
         version = parts[1]
+        if version.endswith('.img'):
+            version = version[:-4]
+        log.info('Item version is %s', version)
 
         if not version in items:
+            log.info('Adding item %s to list', name)
             items[version] = {}
 
         items[version][key] = os.path.join(path, name)
 
+    log.info('Found items: %s', items)
     return items
 
 def get_newest_option(opts):
+    log.info('Getting latest boot item version')
     latest_version = None
     latest_option = None
 
     for version, option in opts.items():
+        log.info('Checking option %s', option)
         # If option is not complete, skip
         if 'kernel' not in option or 'initrd' not in option:
+            log.info('%s does not contain all items, skipping...', version)
             continue
 
         # If this option is newer, store this option and continue
         if latest_version is None or vCompare (version, latest_version):
+            log.info('%s is the latest version', version)
             latest_version = version
             latest_option = option
     
     return latest_option, latest_version
 
 def latest_option(path):
+    log.info('Checking for boot items in %s', path)
     opts = options(path)
     latest_option, latest_version = get_newest_option(opts)
     
@@ -66,6 +84,8 @@ def latest_option(path):
     if len(opts) > 0:
         previous_option, latest_version = get_newest_option(opts)
 
+    log.info('Latest option: %s', latest_option)
+    log.info('Previous option: %s', previous_option)
     return latest_option, previous_option
 
 if __name__ == "__main__":

--- a/kernelstub/opsys.py
+++ b/kernelstub/opsys.py
@@ -129,6 +129,13 @@ class OS():
                 like = item.split('=')[1]
                 like = self.strip_quotes(like)
                 return like.split()
+            
+        # Fallback on ID= if we aren't on a derivative
+        for item in os_release:
+            if item.startswith('ID='):
+                like = item.split('=')[1]
+                like = self.strip_quotes(like)
+                return like.split()
 
     def strip_quotes(self, value):
         new_value = value

--- a/kernelstub/opsys.py
+++ b/kernelstub/opsys.py
@@ -28,6 +28,7 @@ class OS():
 
     name_pretty = "Linux"
     name = "Linux"
+    like = ["Linux"]
     version = "1.0"
     cmdline = ['quiet', 'splash']
     kernel_name = 'vmlinuz'
@@ -43,6 +44,7 @@ class OS():
     def __init__(self):
         self.name_pretty = self.get_os_name()
         self.name = self.clean_names(self.name_pretty)
+        self.like = self.get_os_like()
         self.version = self.get_os_version()
         self.cmdline = self.get_os_cmdline()
 
@@ -116,6 +118,14 @@ class OS():
             if item.startswith('VERSION_ID='):
                 version =  item.split('=')[1]
                 return self.strip_quotes(version[:-1])
+    
+    def get_os_like(self):
+        os_release = self.get_os_release()
+        for item in os_release:
+            if item.startswith('ID_LIKE='):
+                like = item.split('=')[1]
+                like = self.strip_quotes(like)
+                return like.split()
 
     def strip_quotes(self, value):
         new_value = value

--- a/kernelstub/opsys.py
+++ b/kernelstub/opsys.py
@@ -22,7 +22,7 @@ Please see the provided LICENSE.txt file for additional distribution/copyright
 terms.
 """
 
-import platform
+import logging, platform
 
 class OS():
 
@@ -43,6 +43,7 @@ class OS():
     os_mode = 'debian'
 
     def __init__(self):
+        self.log = logging.getLogger('kernelstub.Opsys')
         self.name_pretty = self.get_os_name()
         self.name = self.clean_names(self.name_pretty)
         self.like = self.get_os_like()

--- a/kernelstub/opsys.py
+++ b/kernelstub/opsys.py
@@ -40,6 +40,7 @@ class OS():
     initrd_path = '/initrd.img'
     old_kernel_path = '/vmlinuz.old'
     old_initrd_path = '/initrd.img.old'
+    os_mode = 'debian'
 
     def __init__(self):
         self.name_pretty = self.get_os_name()
@@ -47,6 +48,7 @@ class OS():
         self.like = self.get_os_like()
         self.version = self.get_os_version()
         self.cmdline = self.get_os_cmdline()
+        self.set_os_mode()
 
     def clean_names(self, name):
         # This is a list of characters we can't/don't want to have in technical
@@ -134,6 +136,12 @@ class OS():
         if value.endswith('"'):
             new_value = new_value[:-1]
         return new_value
+    
+    def set_os_mode(self):
+        if 'debian' in self.like:
+            self.os_mode = 'debian'
+        elif 'fedora' in self.like:
+            self.os_mode = 'fedora'
 
     def get_os_release(self):
         try:

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class Test(Command):
             run_pyflakes3()
 
 setup(name='kernelstub',
-    version='4.0.0',
+    version='4.0.1',
     description='Automatic kernel efistub manager for UEFI',
     url='https://launchpad.net/kernelstub',
     author='Ian Santopietro',

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ class Test(Command):
             run_pyflakes3()
 
 setup(name='kernelstub',
-    version='3.1.4',
+    version='4.0.0',
     description='Automatic kernel efistub manager for UEFI',
     url='https://launchpad.net/kernelstub',
     author='Ian Santopietro',


### PR DESCRIPTION
This adds support for systems which don't use the `/vmlinuz` and `/initrd.img` symlinks for kernel management. This includes changes which allow it to operate automatically following a kernel upgrade and logic changes for version detection. It also makes the dependency on python-debian a soft dependency, and attempts to fallback on python-rpm if it isn't available. These changes should not affect the usage of kernelstub on debian-based OSs. 