### PR TITLE
add option to preserve NVRAM boot order

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ There are other options as well, as detailed below:
 |`-l`, `--loader`                           | Create a `systemd-boot`-compatible loader config.*     |
 |`-n`, `--no-loader`		                | Turns off creating the loader configuration.	         |
 |`-s`, `--stub`                             | Set up NVRAM entries for the copied kernel.            |
+|`--preserve-boot-order`                    | Do not change the boot order when updating NVRAM.      |
 |`-m`, `--manage-only`	                    | Don't set up any NVRAM entries.*                       |
 |`-f`, `--force-update`                     | Forcefully update the main loader.conf.**              |
 

--- a/bin/kernelstub
+++ b/bin/kernelstub
@@ -196,6 +196,13 @@ def main(options=None): # Do the thing
         help = 'Set up NVRAM entries for the copied kernel'
     )
 
+    parser.add_argument(
+        '--preserve-boot-order',
+        action = 'store_true',
+        dest = 'preserve_boot_order',
+        help = 'Do not change the boot order when updating NVRAM.'
+    )
+
     loader_stub.add_argument(
         '-m',
         '--manage-only',

--- a/kernelstub/application.py
+++ b/kernelstub/application.py
@@ -248,6 +248,9 @@ class Kernelstub():
         if args.manage_mode:
             configuration['manage_mode'] = True
 
+        if args.preserve_boot_order:
+            configuration['preserve_boot_order'] = True
+        preserve_boot_order = configuration["preserve_boot_order"] == True
 
         log.debug('Checking configuration integrity...')
         try:
@@ -315,6 +318,7 @@ class Kernelstub():
             all_config = (
                 '   ESP Location:..................%s\n' % configuration['esp_path'] +
                 '   Management Mode:...............%s\n' % configuration['manage_mode'] +
+                '   Preserve NVRAM boot order (if not in management mode):..%s\n' % configuration['preserve_boot_order'] +
                 '   Install Loader configuration:..%s\n' % configuration['setup_loader'] +
                 '   Configuration version:.........%s\n' % configuration['config_rev'])
             log.info('Configuration details: \n\n%s' % all_config)
@@ -346,7 +350,7 @@ class Kernelstub():
         installer.copy_cmdline(simulate=no_run)
 
         if not manage_mode:
-            installer.setup_stub(kopts, simulate=no_run)
+            installer.setup_stub(kopts, preserve_boot_order=preserve_boot_order, simulate=no_run)
 
         log.debug('Saving configuration to file')
 

--- a/kernelstub/config.py
+++ b/kernelstub/config.py
@@ -37,9 +37,10 @@ class Config():
             'esp_path': "/boot/efi",
             'setup_loader': False,
             'manage_mode': False,
+            'preserve_boot_order': False,
             'force_update' : False,
             'live_mode' : False,
-            'config_rev' : 3
+            'config_rev' : 4
         }
     }
 
@@ -120,8 +121,11 @@ class Config():
                 config['user']['kernel_options'] = self.parse_options(config['user']['kernel_options'].split())
             if type(config['default']['kernel_options']) is str:
                 config['default']['kernel_options'] = self.parse_options(config['default']['kernel_options'].split())
-        config['user']['config_rev'] = 3
-        config['default']['config_rev'] = 3
+        if config['user']['config_rev'] < 4:
+            config['user']['preserve_boot_order'] = False
+            config['default']['preserve_boot_order'] = False
+        config['user']['config_rev'] = 4
+        config['default']['config_rev'] = 4
         return config
 
     def parse_options(self, options):

--- a/kernelstub/installer.py
+++ b/kernelstub/installer.py
@@ -200,7 +200,7 @@ class Installer():
 
 
 
-    def setup_stub(self, kernel_opts, simulate=False):
+    def setup_stub(self, kernel_opts, preserve_boot_order=False, simulate=False):
         self.log.info("Setting up Kernel EFISTUB loader...")
         self.copy_cmdline(simulate=simulate)
         self.nvram.update()
@@ -212,7 +212,13 @@ class Installer():
         else:
             self.log.debug("No old entry found, skipping removal.")
 
-        self.nvram.add_entry(self.opsys, self.drive, kernel_opts, simulate)
+        self.nvram.add_entry(
+            self.opsys,
+            self.drive,
+            kernel_opts,
+            preserve_boot_order=preserve_boot_order,
+            simulate=simulate
+        )
         self.nvram.update()
         nvram_lines = "\n".join(self.nvram.nvram)
         self.log.info('NVRAM configured, new values: \n\n%s\n' % nvram_lines)

--- a/kernelstub/nvram.py
+++ b/kernelstub/nvram.py
@@ -69,8 +69,9 @@ class NVRAM():
                 return find_index
 
 
-    def add_entry(self, this_os, this_drive, kernel_opts, simulate=False):
+    def add_entry(self, this_os, this_drive, kernel_opts, preserve_boot_order=False, simulate=False):
         self.log.info('Creating NVRAM entry')
+        create_cmd = "-c" if not preserve_boot_order else "-C"
         device = '/dev/%s' % this_drive.drive_name
         esp_num = this_drive.esp_num
         entry_label = '%s %s' % (this_os.name, this_os.version)
@@ -78,7 +79,7 @@ class NVRAM():
         entry_initrd = 'EFI/%s-%s/initrd.img' % (this_os.name, this_drive.root_uuid)
         command = [
             'efibootmgr',
-            '-c',
+            create_cmd,
             '-d', device,
             '-p', esp_num,
             '-L', '%s' % entry_label,


### PR DESCRIPTION
`efibootmgr` has two options: `-c` and `-C`. The latter allows to add a new entry but keep the boot order intact.

I'm using kernelstub in a dual-boot scenario, and also use `systemd-boot` as a bootloader.

I want to keep the `systemd-boot` entry - the default, but I want kernelstub to update the NVRAM entry whenever the kernel upgrades, so that I can use the direct NVRAM entry as a fallback if needed.

Currently, `kernelstub` uses `-c` option only, which brings the newly added entry to front of the boot order, which requires me to reset boot order manually each time the kernel upgrades.


This pull request is a sketch of what I think of, I'm open to suggestions, comments, improvements :)