### PR TITLE
Detect when gzip is used for kernel

### DIFF
--- a/kernelstub/installer.py
+++ b/kernelstub/installer.py
@@ -22,7 +22,7 @@ Please see the provided LICENSE.txt file for additional distribution/copyright
 terms.
 """
 
-import os, shutil, logging, platform, gzip
+import os, shutil, logging, gzip
 
 from pathlib import Path
 
@@ -118,8 +118,7 @@ class Installer():
         self.log.debug('kernel being copied to %s' % self.kernel_dest)
 
         try:
-            arch = platform.machine()
-            if arch == "arm64" or arch == "aarch64":
+            if self.is_gzip(self.opsys.kernel_path):
                 self.gunzip_files(
                     self.opsys.kernel_path,
                     self.kernel_dest,
@@ -243,6 +242,14 @@ class Installer():
                 self.log.exception('Couldn\'t make sure %s exists.' % directory)
                 self.log.debug(e)
                 return False
+
+    def is_gzip(self, path):
+        try:
+            with open(path, 'rb') as file:
+                return file.read(2) == b'\x1f\x8b'
+        except Exception as e:
+            self.log.debug(e)
+            return False
 
     def gunzip_files(self, src, dest, simulate): # Decompress file src to dest
         if simulate:


### PR DESCRIPTION
This allows older gzipped kernels on aarch64 to exist alongside newer EFI executable kernels.